### PR TITLE
Enclosed Wire1 definition in #ifdef precompiling option.

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -390,7 +390,10 @@ void TwoWire::onService(void)
 
 TwoWire Wire(PIN_WIRE_SDA, PIN_WIRE_SCL);
 
+// define Wire1 for Primo Core only
+#ifdef ARDUINO_NRF52_PRIMO_CORE
 TwoWire Wire1(PIN_WIRE_SDA1, PIN_WIRE_SCL1);
+#endif //ARDUINO_NRF52_PRIMO_CORE
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Wire1 has to be defined for Arduino Primo Core only. Removed definition for Arduino Primo to avoid compiling errors.